### PR TITLE
appconfig: When destroying deployments, ignore terminal states.

### DIFF
--- a/aws/resource_aws_appconfig_deployment.go
+++ b/aws/resource_aws_appconfig_deployment.go
@@ -204,7 +204,9 @@ func resourceAwsAppconfigDeploymentDelete(d *schema.ResourceData, meta interface
 		return nil
 	}
 
-	if isAWSErr(err, appconfig.ErrCodeBadRequestException, "it has a status of ROLLED_BACK") {
+	if isAWSErr(err, appconfig.ErrCodeBadRequestException, "it has a status of ROLLED_BACK") ||
+		isAWSErr(err, appconfig.ErrCodeBadRequestException, "it has a status of ROLLING_BACK") ||
+		isAWSErr(err, appconfig.ErrCodeBadRequestException, "it has a status of COMPLETE") {
 		return nil
 	}
 

--- a/aws/resource_aws_appconfig_deployment_test.go
+++ b/aws/resource_aws_appconfig_deployment_test.go
@@ -124,7 +124,9 @@ func testAccCheckAppConfigDeploymentDestroy(s *terraform.State) error {
 		}
 
 		currentState := aws.StringValue(output.State)
-		if currentState == appconfig.DeploymentStateRolledBack || currentState == appconfig.DeploymentStateRollingBack {
+		if currentState == appconfig.DeploymentStateRolledBack ||
+			currentState == appconfig.DeploymentStateRollingBack ||
+			currentState == appconfig.DeploymentStateComplete {
 			return nil
 		}
 


### PR DESCRIPTION
Because deployments are not really destroyed but instead stopped, we
should ignore deployments that are already in a terminal state, including
COMPLETE, ROLLING_BACK, ROLLED_BACK.

Output from acceptance testing:
aws-vault exec dev-admin -- make testacc TESTARGS='-run=TestAccAWSAppConfigDeployment'
https://gist.github.com/bereket42/f5c0497d5ab4f3fff77abb06619ca814

Fixes:
https://app.asana.com/0/1118537407193681/1200154935709646
