### PR TITLE
Merge v.3.69.0 with the exception of ECS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.14.0
 	github.com/hashicorp/aws-sdk-go-base v1.0.0
+	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.17 // indirect
 	github.com/hashicorp/awspolicyequivalence v1.4.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -2,7 +2,6 @@ package verify
 
 import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2/tfawserr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
Essentially this was
```
git rebase v3.69.0
git checkout figma -- internal/service/ecs/{task_set.go,task_set_test.go}
```
and fixing anything that was broke to get `go build` to work.

That is, instead of using the new terraform version's implementation of task_set, I stuck with the old one. The reason i did this is because the migration is hairy.. the attribute names and structures differ 😰 

# Test

`terraform plan` in config/terraform/main in staging/production, verifying that the state files are compatible with this new versioning