### PR TITLE
GoReleaser: Clone code out of gpg action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,29 +32,13 @@ jobs:
         with:
           go-version: 1.16
       -
+        name: Import GPG key
         id: import_gpg
-        name: GPG key import
-        # 2022-07-14: In this import_gpg step, we started encountering this error.
-        #
-        #   gpg-agent: a gpg-agent is already running - not starting a new one
-        #
-        # It happens even if we take an old commit and rerun goreleaser, so its
-        # likely that the github actions environment added a gpg-agent recently
-        # and broke ghaction-import-gpg.
-        #
-        # Below is the logic lifted from ghaction-import-gpg with the exception
-        # of launching the gpg-agent daemon
-        # https://github.com/hashicorp/ghaction-import-gpg/blob/main/action.yml
-        run: |
-          # import GPG key and prime passphrase
-          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty
-          echo "hello world" > temp.txt
-          gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${{ secrets.PASSPHRASE }}" temp.txt
-          rm temp.txt
-
-          # set gpg fingerprint output
-          fingerprint=$(gpg --with-colons --list-keys | awk -F: '/^pub/ { print $5 }')
-          echo "::set-output name=fingerprint::$fingerprint"
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        env:
+          # These secrets will need to be configured for the repository:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,29 @@ jobs:
         with:
           go-version: 1.16
       -
-        name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        name: GPG key import
+        # 2022-07-14: In this import_gpg step, we started encountering this error.
+        #
+        #   gpg-agent: a gpg-agent is already running - not starting a new one
+        #
+        # It happens even if we take an old commit and rerun goreleaser, so its
+        # likely that the github actions environment added a gpg-agent recently
+        # and broke ghaction-import-gpg.
+        #
+        # Below is the logic lifted from ghaction-import-gpg with the exception
+        # of launching the gpg-agent daemon
+        # https://github.com/hashicorp/ghaction-import-gpg/blob/main/action.yml
+        run: |
+          # import GPG key and prime passphrase
+          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch --no-tty
+          echo "hello world" > temp.txt
+          gpg --detach-sig --yes -v --output=/dev/null --pinentry-mode loopback --passphrase "${{ secrets.PASSPHRASE }}" temp.txt
+          rm temp.txt
+
+          # set gpg fingerprint output
+          fingerprint=$(gpg --with-colons --list-keys | awk -F: '/^pub/ { print $5 }')
+          echo "::set-output name=fingerprint::$fingerprint"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0


### PR DESCRIPTION
Goreleaser is bumping into this error:

<img width="593" alt="Screen Shot 2022-07-14 at 20 10 54" src="https://user-images.githubusercontent.com/185076/179142401-6331205e-b140-4de5-a565-f9e1066dd4f7.png">

I took an old commit sha and pushed it again, and it hit the same issue. The other day I wasn't having this issue, I was trying to fix an issue further in the pipeline but it seemed to regress. I suspect that the github actions environment very recently changed, breaking this.

This PR takes most logic out of the action we were depending on and just runs that directly so that we can avoid the step with the gpg agent.

# Test

made it at least beyond that part

<img width="613" alt="Screen Shot 2022-07-14 at 20 13 35" src="https://user-images.githubusercontent.com/185076/179142713-9fc81a9a-d972-41dd-8c23-d8489cade18a.png">

