### PR TITLE
Fix GPG issue in gorelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
+        uses: crazy-max/ghaction-import-gpg@v5.0.0
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,18 +16,11 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    - freebsd
-    - windows
     - linux
     - darwin
   goarch:
     - amd64
-    - '386'
-    - arm
     - arm64
-  ignore:
-    - goos: darwin
-      goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Switches `hashicorp/ghaction-import-gpg@v2.1.0` to `crazy-max/ghaction-import-gpg@v5.0.0`

Also speeds up release from 1h30m to 30m by getting rid of build targets that we don't need.

# Test

Got it to build: https://github.com/figma/terraform-provider-aws/runs/7364855732 (i'm gonna reset all the tag names I used and go back to v3.69.0-figma.0 since none of these were ever used from terraform perspective)

Then did a terraform plan from main

