### PR TITLE
add environment variables to run config (backport hashicorp #23574)

### DIFF
--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -319,6 +319,7 @@ func TestAccSyntheticsCanary_run(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.memory_in_mb", "1000"),
 					resource.TestCheckResourceAttr(resourceName, "run_config.0.timeout_in_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "run_config.0.environment_variables.foo", "bar"),
 				),
 			},
 			{
@@ -750,7 +751,10 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds = 60
+    timeout_in_seconds    = 60
+	environment_variables = {
+		foo = "bar"
+	}
   }
 }
 `, rName))

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -751,7 +751,7 @@ resource "aws_synthetics_canary" "test" {
   }
 
   run_config {
-    timeout_in_seconds    = 60
+    timeout_in_seconds = 60
     environment_variables = {
       foo = "bar"
     }

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -752,9 +752,9 @@ resource "aws_synthetics_canary" "test" {
 
   run_config {
     timeout_in_seconds    = 60
-	environment_variables = {
-		foo = "bar"
-	}
+    environment_variables = {
+      foo = "bar"
+    }
   }
 }
 `, rName))


### PR DESCRIPTION
Backport https://github.com/hashicorp/terraform-provider-aws/pull/23574 to be able to set env vars on synthetics.